### PR TITLE
compute MPI library version in Lisp

### DIFF
--- a/mpi/cl-mpi-stub.c
+++ b/mpi/cl-mpi-stub.c
@@ -71,8 +71,3 @@ defgetter( MPI_Op, MPI_OP_NULL )
 defgetter( MPI_Request, MPI_REQUEST_NULL )
 defgetter( MPI_Status*, MPI_STATUS_IGNORE )
 
-int cl_mpi_some_dummy_function() {
-    int flag;
-    MPI_Initialized(&flag);
-    return flag;
-}

--- a/mpi/cl-mpi-stub.c
+++ b/mpi/cl-mpi-stub.c
@@ -1,24 +1,6 @@
 
 #include <mpi.h>
 
-#define xstr(s) str(s)
-#define str(s) #s
-
-#ifdef MPICH_VERSION
-#define MPI_IMPLEMENTATION_VERSION "MPICH " MPICH_VERSION
-#elif MPICH2_VERSION
-#define MPI_IMPLEMENTATION_VERSION "MPICH2 " MPICH2_VERSION
-#elif OMPI_MAJOR_VERSION
-#define MPI_IMPLEMENTATION_VERSION \
-    "Open MPI " xstr(OMPI_MAJOR_VERSION) "." xstr(OMPI_MINOR_VERSION) "." xstr(OMPI_RELEASE_VERSION)
-#else
-#define MPI_IMPLEMENTATION_VERSION ""
-#endif
-
-char* cl_mpi_get_MPI_LIBRARY() {
-    return MPI_IMPLEMENTATION_VERSION;
-}
-
 /*
   Unfortunately MPI makes no guarantees on the data type of its fundamental
   constants (MPI_COMM_WORLD and the like). In practice, MPICH and its

--- a/mpi/grovel.lisp
+++ b/mpi/grovel.lisp
@@ -6,8 +6,15 @@
 
 ;;; optional and MPI implementation specific constants
 (constant (|MPICH| "MPICH") :optional t)
+(constant (|MPICH_VERSION| "MPICH_VERSION") :optional t)
+
 (constant (|MPICH2| "MPICH2") :optional t)
+(constant (|MPICH2_VERSION| "MPICH2_VERSION") :optional t)
+
 (constant (|OPEN_MPI| "OPEN_MPI") :optional t)
+(constant (|OPEN_MPI_MAJOR_VERSION| "OMPI_MAJOR_VERSION") :optional t)
+(constant (|OPEN_MPI_MINOR_VERSION| "OMPI_MINOR_VERSION") :optional t)
+(constant (|OPEN_MPI_RELEASE_VERSION| "OMPI_RELEASE_VERSION") :optional t)
 
 ;;; standardized MPI constants
 

--- a/mpi/packages.lisp
+++ b/mpi/packages.lisp
@@ -97,7 +97,6 @@
 
    #:mpi-equal
    #:mpi-null
-   #:with-static-vectors
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; datatypes.lisp

--- a/mpi/setup.lisp
+++ b/mpi/setup.lisp
@@ -169,6 +169,18 @@ Example: +mpi-comm-world+ -> \"cl_mpi_get_MPI-COMM-WORLD\""
   "A string describing the MPI library that CL-MPI uses to send its
   messages. Something like \"Open MPI 1.6.2\" ")
 
+(defun get-mpi-library-version ()
+  "Return a string indicating the version of the specific MPI library that
+has been groveled at compile time."
+  (cond
+    ((boundp '|MPICH|) (format nil "MPICH ~D" (symbol-value '|MPICH_VERSION|)))
+    ((boundp '|MPICH2|) (format nil "MPICH2 ~D" (symbol-value '|MPICH2_VERSION|)))
+    ((boundp '|OPEN_MPI|) (format nil "Open MPI ~D.~D.~D"
+                                  (symbol-value '|OPEN_MPI_MAJOR_VERSION|)
+                                  (symbol-value '|OPEN_MPI_MINOR_VERSION|)
+                                  (symbol-value '|OPEN_MPI_RELEASE_VERSION|)))
+    (t "")))
+
 (defun initialize-mpi-constants ()
   "Initialize (or reinitialize) all objects denoted by the symbols in
   *MPI-CONSTANTS* to their values in the underlying MPI C library."
@@ -181,8 +193,7 @@ Example: +mpi-comm-world+ -> \"cl_mpi_get_MPI-COMM-WORLD\""
   ;; not of type MPI-OBJECT
   (setf +mpi-status-ignore+
         (mpi-symbol-value '+mpi-status-ignore+ :pointer))
-  (setf +mpi-library+
-        (mpi-symbol-value '+mpi-library+ :string)))
+  (setf +mpi-library+ (get-mpi-library-version)))
 
 (defmacro define-mpi-constant (class-sym name-sym)
   `(progn

--- a/mpi/utilities.lisp
+++ b/mpi/utilities.lisp
@@ -277,13 +277,3 @@ session is resumed from a Lisp image"
      (mpi-errhandler +mpi-errhandler-null+)
      (t nil))))
 
-(defmacro with-static-vectors ((&optional ((var length &rest args)
-                                           '(nil nil) supplied-p)
-                                &rest more-clauses)
-                               &body body)
-  "Wrap BODY into multiple invocations of WITH-STATIC-VECTOR."
-  (if supplied-p
-      `(with-static-vector (,var ,length ,@args)
-         (with-static-vectors ,more-clauses
-           ,@body))
-      `(progn ,@body)))


### PR DESCRIPTION
This is a first commit attempting to simplify (or eliminate) the stub library.

It also contains a few other trivial simplifications (mostly deleted code).
