### PR TITLE
Don't export +mpi-status-ignore+

### DIFF
--- a/mpi/packages.lisp
+++ b/mpi/packages.lisp
@@ -32,7 +32,6 @@
    #:mpi-request
 
    ;; MPI constants
-   #:+mpi-status-ignore+
    #:+mpi-library+
    #:+mpi-implementation+
    #:+mpi-implementation-version+


### PR DESCRIPTION
It seems that cl-mpi has replaced the use of `+mpi-status-ignore+` by `cffi:null-pointer`. However the (unbound) symbol was still being exported. This PR changes this.