### PR TITLE
Remove references to cl-mpi-benchmarks in cl-mpi.ros

### DIFF
--- a/roswell/cl-mpi.ros
+++ b/roswell/cl-mpi.ros
@@ -9,14 +9,14 @@ exec ros -Q -- $0 "$@"
 (in-package :ros.script.cl-mpi.3657791497)
 
 (ql:quickload
- '(:cffi-grovel :uiop :cl-mpi-benchmarks :cl-mpi-test-suite)
+ '(:cffi-grovel :uiop :cl-mpi-test-suite)
  :silent t)
 
 (defun main (&rest argv)
   (unwind-protect
        (cond
-         ((string-equal (first argv) "benchmark")
-          (cl-mpi-benchmarks:run-benchmarks))
+         ((string-equal (first argv) "stress")
+          (cl-mpi-test-suite:run-cl-mpi-stress-tests))
          (t
           (cl-mpi-test-suite:run-cl-mpi-test-suite)))
     (ignore-errors


### PR DESCRIPTION
Replace `cl-mpi-benchmarks:run-benchmarks` with `cl-mpi-test-suite:run-cl-mpi-stress-tests`.

Prior to these changes, attempting to run `./roswell/cl-mpi.ros` resulted in the following error:

```
Unhandled QUICKLISP-CLIENT:SYSTEM-NOT-FOUND in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                         {10005B05B3}>:
  System "cl-mpi-benchmarks" not found
```

With these changes, `mpiexec -np 2 ./roswell/cl-mpi.ros` and `mpiexec -np 2 ./roswell/cl-mpi.ros stress` both succeed.

Only tested with SBCL 1.5.3.