### PR TITLE
Open MPI 4.0 support

### DIFF
--- a/mpi/packages.lisp
+++ b/mpi/packages.lisp
@@ -41,8 +41,6 @@
    #:+mpi-group-empty+
    #:+mpi-comm-world+
    #:+mpi-comm-self+
-   #:+mpi-lb+
-   #:+mpi-ub+
    #:+mpi-char+
    #:+mpi-signed-char+
    #:+mpi-unsigned-char+

--- a/mpi/setup.lisp
+++ b/mpi/setup.lisp
@@ -201,8 +201,6 @@ THE SOFTWARE.
 (define-mpi-constant mpi-comm "MPI_COMM_SELF")
 (define-mpi-constant mpi-comm "MPI_COMM_NULL")
 (define-mpi-constant mpi-datatype "MPI_DATATYPE_NULL")
-(define-mpi-constant mpi-datatype "MPI_LB")
-(define-mpi-constant mpi-datatype "MPI_UB")
 (define-mpi-constant mpi-datatype "MPI_CHAR")
 (define-mpi-constant mpi-datatype "MPI_SIGNED_CHAR")
 (define-mpi-constant mpi-datatype "MPI_UNSIGNED_CHAR")


### PR DESCRIPTION
This is PR enables building cl-mpi against Open MPI 4.0 by removing the constants `MPI_UB` and `MPI_LB`.

The Open MPI 4.0 upgrade guide claims these symbols were deprecated in MPI-2.0 in 1996 :eyes:, then actually removed from the spec with MPI-3.0 in 2012. If only everyone took backwards compatibility this seriously!

<https://www.open-mpi.org/software/ompi/major-changes.php>
<https://www.open-mpi.org/faq/?category=mpi-removed#mpi.h-deleted-prototypes>

I was originally planning to only drop these constants for Open MPI 4.0+, but I am 100% new to MPI and cl-mpi, so I've gone with a minimal diff to get the build working "on my machine" and to get the PR conversation started.

Adding an `until-mpi-version` macro that mirrors the pre-existing `since-mpi-version` and conditionally excluding the symbols based only on `MPI_VERSION` (as opposed to `OMPI_MAJOR_VERSION`) seemed like the least intrusive change from a lines-of-diff standpoint, though perhaps not from a backwards-compatibility standpoint.  Feedback welcome.

Note that I haven't (yet) touched the `+mpi-ub+` and `+mpi-lb+` that appear in the `:export` clause of the cli-mpi `defpackage`, which means they will now be unbound on MPI 3.0+ implementations. I'm not super thrilled about it, but this seemed to be in keeping with the way constants currently guarded by the `(since-mpi-version "2.2" ...)` are handled. Plus, I'm lazy.

For reference, here are the relevant excerpts of the errors I got when attempting to build cl-mpi against Open MPI 4.0.1 prior to these changes:

    ~/.cache/.../cl-mpi/mpi/wrap__wrapper.c:214:10: error: ‘MPI_UB’ undeclared (first use in this function); did you mean ‘MPI_IO’?
       return MPI_UB;
              ^~~~~~
              MPI_IO
    ...
    ~/.cache/.../cl-mpi/mpi/wrap__wrapper.c:219:10: error: ‘MPI_LB’ undeclared (first use in this function); did you mean ‘MPI_IO’?
       return MPI_LB;
              ^~~~~~
              MPI_IO

After these changes, `./scripts/run-test-suite.sh sbcl ccl` completes with no test failures.

ECL is another story. See #23.

Finally here is the less-abridged error message I get when running the test suite prior to these changes:

    [ma@march cl-mpi]? ./scripts/run-test-suite.sh sbcl
    =========================================
    Building sbcl (SBCL 1.4.16) image ...
    ; mpicc -o /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel-tmpAAURSO1.o -c -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -D_GNU_SOURCE -fno-omit-frame-pointer -DSBCL_HOME=/usr/lib/sbcl -g -Wall -Wundef -Wsign-compare -Wpointer-arith -O3 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wunused-parameter -fno-omit-frame-pointer -momit-leaf-frame-pointer -fno-pie -fPIC -I/home/ma/opt/quicklisp/dists/quicklisp/software/cffi_0.20.0/ /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel.c
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel.c: In function ‘main’:
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel.c:11:7: warning: unused variable ‘autotype_tmp’ [-Wunused-variable]
       int autotype_tmp;
           ^~~~~~~~~~~~
    ; mpicc -o /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel-tmp5GEXGEG5 -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -g -Wl,--export-dynamic -no-pie /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel.o
    ; /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/grovel__grovel.grovel-tmp.lisp
    ; mpicc -o /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o -c -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -D_GNU_SOURCE -fno-omit-frame-pointer -DSBCL_HOME=/usr/lib/sbcl -g -Wall -Wundef -Wsign-compare -Wpointer-arith -O3 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Wunused-parameter -fno-omit-frame-pointer -momit-leaf-frame-pointer -fno-pie -fPIC -I/home/ma/opt/quicklisp/dists/quicklisp/software/cffi_0.20.0/ /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c: In function ‘cl_mpi_get_mpi_ub_cffi_wrap’:
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c:214:10: error: ‘MPI_UB’ undeclared (first use in this function); did you mean ‘MPI_IO’?
       return MPI_UB;
              ^~~~~~
              MPI_IO
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c:214:10: note: each undeclared identifier is reported only once for each function it appears in
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c: In function ‘cl_mpi_get_mpi_lb_cffi_wrap’:
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c:219:10: error: ‘MPI_LB’ undeclared (first use in this function); did you mean ‘MPI_IO’?
       return MPI_LB;
              ^~~~~~
              MPI_IO
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c: In function ‘cl_mpi_get_mpi_ub_cffi_wrap’:
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c:215:1: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c: In function ‘cl_mpi_get_mpi_lb_cffi_wrap’:
    /home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c:220:1: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
    Fatal condition:
    Subprocess #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {100239FA13}>
     with command ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" "-DSBCL_HOME=/usr/lib/sbcl" "-g" "-Wall" "-Wundef" "-Wsign-compare" "-Wpointer-arith" "-O3" "-D_LARGEFILE_SOURCE" "-D_LARGEFILE64_SOURCE" "-D_FILE_OFFSET_BITS=64" "-Wunused-parameter" "-fno-omit-frame-pointer" "-momit-leaf-frame-pointer" "-fno-pie" "-fPIC" "-I/home/ma/opt/quicklisp/dists/quicklisp/software/cffi_0.20.0/" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c")
     exited with error code 1
    Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10005205B3}>
    0: ((LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE))
    1: ((FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX))
    2: (SB-IMPL::%WITH-STANDARD-IO-SYNTAX #<CLOSURE (FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX) {7EFC737ADD1B}>)
    3: (UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX #<CLOSURE (LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE) {10023A45DB}> :PACKAGE :CL)
    4: (UIOP/IMAGE:PRINT-CONDITION-BACKTRACE #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10023A25F3}> :STREAM #<SB-SYS:FD-STREAM for "standard error" {1004F90913}> :COUNT NIL)
    5: (UIOP/IMAGE:HANDLE-FATAL-CONDITION #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10023A25F3}>)
    6: (SB-KERNEL::%SIGNAL #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10023A25F3}>)
    7: (CERROR "IGNORE-ERROR-STATUS" UIOP/RUN-PROGRAM:SUBPROCESS-ERROR :COMMAND ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" ...) :CODE 1 :PROCESS #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {100239FA13}>)
    8: (UIOP/RUN-PROGRAM::%CHECK-RESULT 1 :COMMAND ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" ...) :PROCESS #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {100239FA13}> :IGNORE-ERROR-STATUS NIL)
    9: (UIOP/RUN-PROGRAM::%USE-LAUNCH-PROGRAM ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" ...) :OUTPUT :INTERACTIVE :ERROR-OUTPUT :INTERACTIVE)
    ...snip...
    48: (EVAL (PROGN (SET-DISPATCH-MACRO-CHARACTER #\# #\! (LAMBDA (STREAM CHAR SB-DEBUG:ARG) (DECLARE (IGNORE CHAR SB-DEBUG:ARG)) (VALUES (READ-LINE STREAM)))) (LOAD "/usr/bin/cl-launch" :VERBOSE NIL :PRINT NIL) (FUNCALL (INTERN (STRING :RUN) :CL-LAUNCH) :QUICKLISP T :BUILD (QUOTE ((:LOAD-SYSTEM "cl-mpi-test-suite"))) :INIT "(cl:in-package :cl-mpi-test-suite)(unwind-protect (run-cl-mpi-test-suite) (mpi-finalize) (uiop:quit))" :DUMP "./scripts/sbcl.image")))
    49: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . #<(SIMPLE-ARRAY CHARACTER (415)) (progn(set-dispatch-macro-character #\# #\! (lambda(stream char arg)(declare(ignore char arg))(values(read-line stream))))(cl:load "/usr/bin/cl-launch" :verbose nil :print nil)
    (funcall(intern(string ... {10018781EF}>)))
    50: (SB-IMPL::TOPLEVEL-INIT)
    51: ((FLET SB-UNIX::BODY :IN SB-EXT:SAVE-LISP-AND-DIE))
    52: ((FLET "WITHOUT-INTERRUPTS-BODY-14" :IN SB-EXT:SAVE-LISP-AND-DIE))
    53: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))
    Above backtrace due to this condition:
    Subprocess #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {100239FA13}>
     with command ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" "-DSBCL_HOME=/usr/lib/sbcl" "-g" "-Wall" "-Wundef" "-Wsign-compare" "-Wpointer-arith" "-O3" "-D_LARGEFILE_SOURCE" "-D_LARGEFILE64_SOURCE" "-D_FILE_OFFSET_BITS=64" "-Wunused-parameter" "-fno-omit-frame-pointer" "-momit-leaf-frame-pointer" "-fno-pie" "-fPIC" "-I/home/ma/opt/quicklisp/dists/quicklisp/software/cffi_0.20.0/" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c")
     exited with error code 1
    Subprocess #<UIOP/LAUNCH-PROGRAM::PROCESS-INFO {100239FA13}>
     with command ("mpicc" "-o" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper-tmp8V3J6PE9.o" "-c" "-march=x86-64" "-mtune=generic" "-O2" "-pipe" "-fstack-protector-strong" "-fno-plt" "-D_GNU_SOURCE" "-fno-omit-frame-pointer" "-DSBCL_HOME=/usr/lib/sbcl" "-g" "-Wall" "-Wundef" "-Wsign-compare" "-Wpointer-arith" "-O3" "-D_LARGEFILE_SOURCE" "-D_LARGEFILE64_SOURCE" "-D_FILE_OFFSET_BITS=64" "-Wunused-parameter" "-fno-omit-frame-pointer" "-momit-leaf-frame-pointer" "-fno-pie" "-fPIC" "-I/home/ma/opt/quicklisp/dists/quicklisp/software/cffi_0.20.0/" "/home/ma/.cache/common-lisp/sbcl-1.4.16-linux-x64/home/ma/src/repos/cl-mpi/mpi/wrap__wrapper.c")
     exited with error code 1
    ;
    ; compilation unit aborted
    ;   caught 1 fatal ERROR condition
    Failed to dump an image
    ...sbcl image creation failed
    =========================================

EDIT: fixed Open MPI version 4.1 -> 4.0.1