### PR TITLE
Add COLOR and KEY to *MPI-NAMING-CONVENTIONS*

### DIFF
--- a/mpi/utilities.lisp
+++ b/mpi/utilities.lisp
@@ -55,7 +55,7 @@ THE SOFTWARE.
          ((:pointer :boolean) *flag)
          (:int
           count incount outcount insize outsize sendcount recvcount source dest
-          tag sendtag recvtag size root commute errorcode)
+          tag sendtag recvtag size root commute errorcode color key)
          (:boolean flag)
          (mpi-errhandler errhandler)
          (mpi-comm comm oldcomm comm1 comm2)

--- a/test-suite/serial-tests.lisp
+++ b/test-suite/serial-tests.lisp
@@ -64,6 +64,32 @@ program."
       (mpi-comm-free c2)
       (mpi-comm-free c3))))
 
+(test (mpi-split :depends-on mpi-context)
+  "Test that mpi-comm-split is working."
+  (with-fresh-mpi-context
+    (let ((c1 (mpi-comm-split 0 0))
+          (c2 (mpi-comm-split 0 (mpi-comm-rank)))
+          (c3 (mpi-comm-split 0 (- (mpi-comm-rank))))
+          (c4 (mpi-comm-split (mpi-comm-rank) -1))
+          (c5 (mpi-comm-split +mpi-undefined+ 0)))
+      (unwind-protect
+           (progn
+             (is (= (mpi-comm-size c1) (mpi-comm-size)))
+             (is (= (mpi-comm-rank c1) (mpi-comm-rank)))
+             (is (= (mpi-comm-size c2) (mpi-comm-size)))
+             (is (= (mpi-comm-rank c2) (mpi-comm-rank)))
+             (is (= (mpi-comm-size c3) (mpi-comm-size)))
+             (is (= (mpi-comm-rank c3) (- (mpi-comm-size)
+                                          (mpi-comm-rank)
+                                          1)))
+             (is (= (mpi-comm-size c4) 1))
+             (is (= (mpi-comm-rank c4) 0))
+             (is (mpi-null c5))))
+      (mpi-comm-free c1)
+      (mpi-comm-free c2)
+      (mpi-comm-free c3)
+      (mpi-comm-free c4))))
+
 ;;; point to point communication
 
 (test (serial-mpi-sendrecv :depends-on mpi-context)


### PR DESCRIPTION
Prior to this change, the build failed, like so:

    ; file: /home/quicklisp/quicklisp-controller/dist/build-cache/cl-mpi/ab72e2e330571a02451fa733bd7f55c325634dc6/cl-mpi-20190701-git/mpi/contexts.lisp
    ; in: DEFMPIFUN "MPI_Comm_split"
    ;     (MPI::DEFMPIFUN "MPI_Comm_split"
    ;                     (MPI::COMM MPI::COLOR MPI::KEY MPI::*NEWCOMM))
    ; --> MPI::SINCE-MPI-VERSION PROGN
    ; ==>
    ;   (CFFI:DEFCFUN ("MPI_Comm_split" MPI::%MPI-COMM-SPLIT)
    ;       MPI::MPI-ERROR-CODE
    ;     (MPI::COMM MPI:MPI-COMM)
    ;     (MPI::COLOR NIL)
    ;     (MPI::KEY NIL)
    ;     (MPI::*NEWCOMM (:POINTER MPI:MPI-COMM)))
    ;
    ; caught ERROR:
    ;   (during macroexpansion of (DEFCFUN ("MPI_Comm_split" %MPI-COMM-SPLIT) ...))
    ;   The value of SYMBOL is NIL, which is not of type (AND SYMBOL (NOT NULL)).
    Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread
    ; #<SB-THREAD:THREAD "main thread" RUNNING {10005E05B3}>:
    ; COMPILE-FILE-ERROR while compiling #<CL-SOURCE-FILE "cl-mpi" "mpi"
    ; "contexts">

See also:

https://github.com/marcoheisig/cl-mpi/pull/25#issuecomment-507307193
https://github.com/marcoheisig/cl-mpi/pull/20


Tested against the following lisp and open mpi versions:

SBCL 1.5.3
CCL Version 1.12-dev  LinuxX8664
Open MPI 3.1.3
Open MPI 4.0.1