### PR TITLE
TravisCI enabled for cl-mpi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: common-lisp
+sudo: true
+dist: trusty
+
+env:
+  global:
+    - HYDRA_LAUNCHER=fork
+    - OMPI_MCA_plm=isolated
+    - OMPI_MCA_rmaps_base_oversubscribe=true
+  matrix:
+    - MPI=mpich
+    - MPI=openmpi
+
+cache:
+  directories:
+    - $HOME/sbcl
+    - $HOME/quicklisp
+    - $HOME/sbcl-install
+
+branches:
+  only:
+    - master
+    - ci/travis
+
+git:
+  depth: 3
+
+cache:
+  apt: true
+
+addons:
+  apt:
+    update: true
+
+before_install:
+  - ./conf/travis-ci/install-mpi.sh $MPI
+
+install:
+  - git clone git://git.code.sf.net/p/sbcl/sbcl; cd sbcl; sh make.sh --prefix=$HOME/sbcl-install --fancy --with-sb-linkable-runtime --with-sb-dynamic-core && sh install.sh
+  - curl -O https://beta.quicklisp.org/quicklisp.lisp; $HOME/sbcl-install/bin/sbcl --load quicklisp.lisp
+  - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
+
+before_script:
+  - export PATH=$PATH:$PWD/sbcl-install/bin
+
+script:
+  - ./scripts/run-test-suite.sh sbcl
+
+#notifications:
+#  email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
+  - cd $HOME; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - curl -O https://beta.quicklisp.org/quicklisp.lisp; cp conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
+  - curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
     - $HOME/sbcl
     - $HOME/quicklisp
-    - $HOME/sbcl-install
+
 
 branches:
   only:
@@ -36,12 +36,12 @@ before_install:
   - ./conf/travis-ci/install-mpi.sh $MPI
 
 install:
-  - git clone git://git.code.sf.net/p/sbcl/sbcl; cd sbcl; sh make.sh --prefix=$HOME/sbcl-install --fancy --with-sb-linkable-runtime --with-sb-dynamic-core && sh install.sh
-  - curl -O https://beta.quicklisp.org/quicklisp.lisp; $HOME/sbcl-install/bin/sbcl --load quicklisp.lisp
+  - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
+  - curl -O https://beta.quicklisp.org/quicklisp.lisp; $HOME/sbcl/bin/sbcl --load quicklisp.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:
-  - export PATH=$PATH:$PWD/sbcl-install/bin
+  - export PATH=$PATH:$PWD/sbcl/bin
 
 script:
   - ./scripts/run-test-suite.sh sbcl

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - HYDRA_LAUNCHER=fork
     - OMPI_MCA_plm=isolated
     - OMPI_MCA_rmaps_base_oversubscribe=true
+    - SBCL_HOME=$HOME/sbcl/lib/sbcl
   matrix:
     - MPI=mpich
     - MPI=openmpi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - cd $HOME; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
+  - cd pavanakumar/cl-mpi; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - curl -O https://beta.quicklisp.org/quicklisp.lisp; $HOME/sbcl/bin/sbcl --load quicklisp.lisp
+  - curl -O https://beta.quicklisp.org/quicklisp.lisp; cp conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - export PATH=$PATH:$PWD/sbcl/bin
 
 script:
-  - ./scripts/run-test-suite.sh sbcl
+  - $HOME/quicklisp/local-projects/cl-mpi/scripts/run-test-suite.sh sbcl
 
 #notifications:
 #  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - cd pavanakumar/cl-mpi; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
+  - cd $HOME/pavanakumar/cl-mpi; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,11 @@ addons:
 
 before_install:
   - ./conf/travis-ci/install-mpi.sh $MPI
-
+  - cp ./conf/travis-ci/install.lisp .
 install:
-  - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
-  - pwd
-  - cd $HOME/pavanakumar/cl-mpi; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
-  - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
+  - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh ; cd ..
+  - curl -O https://beta.quicklisp.org/quicklisp.lisp; $HOME/sbcl/bin/sbcl --load install.lisp
+  - cd $HOME/quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 
 before_script:
   - export PATH=$PATH:$PWD/sbcl/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
 
 install:
   - wget http://prdownloads.sourceforge.net/sbcl/sbcl-1.5.4-x86-64-linux-binary.tar.bz2; tar -jxvf sbcl-1.5.4-x86-64-linux-binary.tar.bz2; cd sbcl-1.5.4-x86-64-linux; INSTALL_ROOT=$HOME/sbcl sh install.sh 
+  - pwd
   - cd $HOME/pavanakumar/cl-mpi; curl -O https://beta.quicklisp.org/quicklisp.lisp; cp ./conf/travis-ci/install.lisp . ; $HOME/sbcl/bin/sbcl --load install.lisp
   - cd quicklisp/local-projects; git clone https://github.com/marcoheisig/cl-mpi.git
 

--- a/README.org
+++ b/README.org
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master)](https://travis-ci.org/pavanakumar/cl-mpi)
+
 #+TITLE: cl-mpi
 
 cl-mpi provides convenient CFFI bindings for the Message Passing

--- a/README.org
+++ b/README.org
@@ -1,6 +1,4 @@
-[![Build Status](https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master)](https://travis-ci.org/pavanakumar/cl-mpi)
-
-#+TITLE: cl-mpi
+#+TITLE: cl-mpi [![Build Status](https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master)](https://travis-ci.org/pavanakumar/cl-mpi)
 
 cl-mpi provides convenient CFFI bindings for the Message Passing
 Interface (MPI). MPI is typically used in High Performance Computing to

--- a/README.org
+++ b/README.org
@@ -1,4 +1,7 @@
-#+TITLE: cl-mpi [![Build Status](https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master)](https://travis-ci.org/pavanakumar/cl-mpi)
+#+TITLE: cl-mpi
+
+.. image::  https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master
+   :target: https://travis-ci.org/pavanakumar/cl-mpi
 
 cl-mpi provides convenient CFFI bindings for the Message Passing
 Interface (MPI). MPI is typically used in High Performance Computing to

--- a/README.org
+++ b/README.org
@@ -1,5 +1,7 @@
 #+TITLE: cl-mpi
 
+#+CAPTION: Build status
+#+NAME:   fig:travis-build-status
 [[https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master]]
 
 

--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 #+TITLE: cl-mpi
 
-.. image::  https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master
-   :target: https://travis-ci.org/pavanakumar/cl-mpi
+[[https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master]]
+
 
 cl-mpi provides convenient CFFI bindings for the Message Passing
 Interface (MPI). MPI is typically used in High Performance Computing to

--- a/conf/travis-ci/install-mpi.sh
+++ b/conf/travis-ci/install-mpi.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+case `uname` in
+Linux)
+  case $1 in
+    mpich) set -x;
+      sudo apt-get install -y -q mpich libmpich-dev
+      ;;
+    openmpi) set -x;
+      sudo apt-get install -y -q openmpi-bin libopenmpi-dev
+      ;;
+    *)
+      echo "Unknown MPI implementation:" $1
+      exit 1
+      ;;
+  esac
+  ;;
+Darwin)
+  case $1 in
+    mpich) set -x;
+      brew install mpich
+      ;;
+    openmpi) set -x;
+      brew install openmpi
+      ;;
+    *)
+      echo "Unknown MPI implementation:" $1
+      exit 1
+      ;;
+  esac
+  ;;
+esac
+

--- a/conf/travis-ci/install.lisp
+++ b/conf/travis-ci/install.lisp
@@ -1,0 +1,3 @@
+(load "quicklisp.lisp")
+(quicklisp-quickstart:install)
+(quit)


### PR DESCRIPTION
This commit enables TravisCI support for cl-mpi. The build-passing icon is also displayed on the README.org file.

*TODO* : *Register in [TravisCI this project](https://travis-ci.org/marcoheisig/cl-mpi) and change the text in* ```README.org```

from
```
#+CAPTION: Build status
#+NAME:   fig:travis-build-status
[[https://travis-ci.org/pavanakumar/cl-mpi.svg?branch=master]]
```
to

```
#+CAPTION: Build status
#+NAME:   fig:travis-build-status
[[https://travis-ci.org/marcoheisig/cl-mpi.svg?branch=master]]
```


